### PR TITLE
update subuser_access example after changing schema to Set

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Related Issue
+
+Fixes # <!-- INSERT ISSUE NUMBER -->
+
+## Description
+
+In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.
+
+<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
+## Rollback Plan
+
+- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.
+
+## Changes to Security Controls
+
+Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

--- a/docs/resources/sso_teammate.md
+++ b/docs/resources/sso_teammate.md
@@ -24,7 +24,7 @@ Manage a Twilio SendGrid SSO Teammate and optional per‑Subuser restricted acce
 
 - `first_name` (String) Teammate first name.
 - `last_name` (String) Teammate last name.
-- `subuser_access` (Block List) Per‑Subuser access when `has_restricted_subuser_access = true`. For `permission_type = restricted`, `scopes` must list allowed scopes. (see [below for nested schema](#nestedblock--subuser_access))
+- `subuser_access` (Block Set) Per‑Subuser access when `has_restricted_subuser_access = true`. For `permission_type = restricted`, `scopes` must list allowed scopes. (see [below for nested schema](#nestedblock--subuser_access))
 
 ### Read-Only
 

--- a/examples/resources/sso_teammate/resource.tf
+++ b/examples/resources/sso_teammate/resource.tf
@@ -2,8 +2,8 @@
 # Provider configuration
 ############################
 provider "sendgrid" {
-  # api_key は未指定時、環境変数 SENDGRID_API_KEY を使用します
-  # base_url は省略時 US (https://api.sendgrid.com)。EU の場合は以下を有効化:
+  # If api_key is not specified, the environment variable SENDGRID_API_KEY is used
+  # base_url defaults to US (https://api.sendgrid.com). For EU, enable the following:
   # base_url = "https://api.eu.sendgrid.com"
 }
 
@@ -15,23 +15,21 @@ resource "sendgrid_sso_teammate" "readonly" {
   first_name = "Read"
   last_name  = "Only"
 
-  # Subuser 単位で権限管理を行う場合は true
+  # Set to true to manage permissions per Subuser
   has_restricted_subuser_access = true
 
-  # 付与する Subuser ごとのアクセス設定
-  subuser_access = [
-    {
-      id              = 1234567      # ← 既存 Subuser の ID に置き換え
-      permission_type = "restricted" # "restricted" | "admin"
-      scopes = [                     # restricted の場合は許可スコープを列挙
-        "messages.read",
-        "stats.read",
-        "user.account.read",
-        "user.username.read",
-        "tracking_settings.read",
-      ]
-    }
-  ]
+  # Access settings for each assigned Subuser
+  subuser_access {
+    id              = 1234567      # ← Replace with the ID of an existing Subuser
+    permission_type = "restricted" # "restricted" | "admin"
+    scopes = [                     # For "restricted", list the allowed scopes
+      "messages.read",
+      "stats.read",
+      "user.account.read",
+      "user.username.read",
+      "tracking_settings.read",
+    ]
+  }
 }
 
 ############################
@@ -42,25 +40,24 @@ resource "sendgrid_sso_teammate" "ops" {
 
   has_restricted_subuser_access = true
 
-  subuser_access = [
-    {
-      id              = 1111111
-      permission_type = "restricted"
-      scopes = [
-        "messages.read",
-        "stats.read",
-      ]
-    },
-    {
-      id              = 2222222
-      permission_type = "admin" # admin の場合、scopes は無視されます
-      scopes          = []
-    }
-  ]
+  subuser_access {
+    id              = 1111111
+    permission_type = "restricted"
+    scopes = [
+      "messages.read",
+      "stats.read",
+    ]
+  }
+
+  subuser_access {
+    id              = 2222222
+    permission_type = "admin" # For "admin", scopes are ignored
+    scopes          = []
+  }
 }
 
 ############################
-# Useful outputs during testing
+# Useful outputs for testing
 ############################
 output "readonly_email" {
   value = sendgrid_sso_teammate.readonly.email

--- a/internal/provider/resource_sso_teammate.go
+++ b/internal/provider/resource_sso_teammate.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -47,7 +46,7 @@ type ssoTeammateModel struct {
 	LastName  types.String `tfsdk:"last_name"`
 
 	HasRestricted types.Bool   `tfsdk:"has_restricted_subuser_access"`
-	SubuserAccess types.List   `tfsdk:"subuser_access"`
+	SubuserAccess types.Set    `tfsdk:"subuser_access"`
 	Status        types.String `tfsdk:"status"`
 }
 
@@ -107,10 +106,10 @@ func (r *SSOTeammateResource) Schema(_ context.Context, _ resource.SchemaRequest
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"subuser_access": schema.ListNestedBlock{
+			"subuser_access": schema.SetNestedBlock{
 				MarkdownDescription: "Per‑Subuser access when `has_restricted_subuser_access = true`. For `permission_type = restricted`, `scopes` must list allowed scopes.",
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.UseStateForUnknown(),
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -343,16 +342,16 @@ func (r *SSOTeammateResource) Create(ctx context.Context, req resource.CreateReq
 			}
 			objs = append(objs, o)
 		}
-		lv, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: map[string]attr.Type{
+		sv, diags := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: map[string]attr.Type{
 			"id": types.Int64Type, "permission_type": types.StringType, "scopes": types.SetType{ElemType: types.StringType},
 		}}, objs)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		plan.SubuserAccess = lv
+		plan.SubuserAccess = sv
 	} else {
-		plan.SubuserAccess = types.ListNull(types.ObjectType{AttrTypes: map[string]attr.Type{
+		plan.SubuserAccess = types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
 			"id": types.Int64Type, "permission_type": types.StringType, "scopes": types.SetType{ElemType: types.StringType},
 		}})
 	}
@@ -485,16 +484,16 @@ func (r *SSOTeammateResource) Read(ctx context.Context, req resource.ReadRequest
 			objs = append(objs, o)
 		}
 		// assign to state.SubuserAccess
-		lv, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: map[string]attr.Type{
+		sv, diags := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: map[string]attr.Type{
 			"id": types.Int64Type, "permission_type": types.StringType, "scopes": types.SetType{ElemType: types.StringType},
 		}}, objs)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		state.SubuserAccess = lv
+		state.SubuserAccess = sv
 	} else {
-		state.SubuserAccess = types.ListNull(types.ObjectType{AttrTypes: map[string]attr.Type{
+		state.SubuserAccess = types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
 			"id": types.Int64Type, "permission_type": types.StringType, "scopes": types.SetType{ElemType: types.StringType},
 		}})
 	}
@@ -654,16 +653,16 @@ func (r *SSOTeammateResource) Update(ctx context.Context, req resource.UpdateReq
 			}
 			objs = append(objs, o)
 		}
-		lv, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: map[string]attr.Type{
+		sv, diags := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: map[string]attr.Type{
 			"id": types.Int64Type, "permission_type": types.StringType, "scopes": types.SetType{ElemType: types.StringType},
 		}}, objs)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		plan.SubuserAccess = lv
+		plan.SubuserAccess = sv
 	} else {
-		plan.SubuserAccess = types.ListNull(types.ObjectType{AttrTypes: map[string]attr.Type{
+		plan.SubuserAccess = types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
 			"id": types.Int64Type, "permission_type": types.StringType, "scopes": types.SetType{ElemType: types.StringType},
 		}})
 	}


### PR DESCRIPTION
## Related Issue

Fixes #2 
## Description

This PR fixes an issue where sendgrid_sso_teammate resources would show unnecessary diffs during terraform plan due to the reordering of subuser_access blocks.
The update ensures a consistent ordering of subuser access IDs, preventing changes from being applied when only the order differs.

## Rollback Plan

No rollback plan is required. This change is non-breaking and only affects the plan output.

## Changes to Security Controls

No changes to security controls.
